### PR TITLE
change most requirements to extras

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -48,9 +48,20 @@ from setuptools import setup
 PROJECT = 'nuna_sql_tools'
 with open('VERSION', 'r', encoding='utf-8') as f:
     VERSION = f.read().strip()
+
+EXTRA_REQUIRED_PACKAGES  = {}
+REQUIRED_PACKAGES = []
 with open('requirements.txt', 'r', encoding='utf-8') as f:
     lines = [l.strip() for l in f.readlines()]
-    REQUIRED_PACKAGES = [l for l in lines if l and not l.startswith('#')]
+    for line in lines:
+        if line.startswith("#"):
+            continue
+        if line.startswith("protobuf") or line.startswith("absl-py"):
+            REQUIRED_PACKAGES.append(line)
+        else:
+            package_name = line.split("==")[0].rstrip("[all]")
+            EXTRA_REQUIRED_PACKAGES[package_name] = [line]
+
 DOCLINES = __doc__.split('\n')
 ENTRY_POINTS = [
     'sql_analyze-viewer=sql_analyze.viewer.viewer:main',
@@ -63,6 +74,7 @@ PACKAGE_DATA = glob.glob(
 
 print(f'Package data: {PACKAGE_DATA}')
 print(f'Required packages: {REQUIRED_PACKAGES}')
+print(f'Extra Required packages: {EXTRA_REQUIRED_PACKAGES}')
 
 setup(
     name=PROJECT,
@@ -90,5 +102,6 @@ setup(
     include_package_data=True,
     entry_points={'console_scripts': ENTRY_POINTS},
     install_requires=REQUIRED_PACKAGES,
+    extras_require=EXTRA_REQUIRED_PACKAGES,
     zip_safe=False,
 )


### PR DESCRIPTION
We set up most of the requirements as extras except for protobuf and abseil. 

Future MR's:
1. don't pin the requirements per https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/?highlight=install_requires, annotate extra requires better for cases where the deps have extras themselves (smart_open)
2. use py_wheel rule from rules_python instead to build the wheel  
3. use pip_parse instead of pip_install for python deps when building.

I can add tests if we want (i tested locally) - this parsing I implemented will fail in certain cases (requirements with >= or <= ) but it works for the way we have requirements.txt set up. prefer to just deprecate setup.py in another MR and change wheel building to py_wheel. what are your thoughts?